### PR TITLE
Add Qt chess program skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+/build
+*.o
+*.a
+*.so
+cmake-build*/
+*.user
+*.pro.user
+*.db

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.5)
+project(chess-qt LANGUAGES CXX)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_CXX_STANDARD 17)
+
+find_package(Qt5 COMPONENTS Widgets Sql REQUIRED)
+
+add_executable(chess-qt
+    src/main.cpp
+    src/login.cpp
+    src/chessgame.cpp
+    resources/resources.qrc
+)
+
+target_include_directories(chess-qt PRIVATE src)
+target_link_libraries(chess-qt Qt5::Widgets Qt5::Sql)
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# chess-qt
+# Chess Qt
+
+This project implements a minimal Qt-based chess program in C++.
+Features include:
+
+- Login and simple registration stored in an SQLite database
+- Basic chess board with piece images
+- Skeleton for AI play via Stockfish (not yet fully implemented)
+- Ten minute timers per side
+
+Build with CMake and Qt5 development packages:
+
+```bash
+mkdir build && cd build
+cmake ..
+make
+./chess-qt
+```
+

--- a/resources/resources.qrc
+++ b/resources/resources.qrc
@@ -1,0 +1,16 @@
+<RCC>
+    <qresource prefix="/images">
+        <file>../bishop_w.png</file>
+        <file>../chess board.png</file>
+        <file>../king_b.png</file>
+        <file>../king_w.png</file>
+        <file>../knight_b.png</file>
+        <file>../knight_w.png</file>
+        <file>../pawn_b.png</file>
+        <file>../pawn_w.png</file>
+        <file>../queen_b.png</file>
+        <file>../queen_w.png</file>
+        <file>../rook_b.png</file>
+        <file>../rook_w.png</file>
+    </qresource>
+</RCC>

--- a/src/chessgame.cpp
+++ b/src/chessgame.cpp
@@ -1,0 +1,65 @@
+#include "chessgame.h"
+#include <QPainter>
+
+ChessGame::ChessGame(bool vsAI, Color aiColor, QWidget* parent)
+    : QWidget(parent), board(64), turn(Color::White), vsAI(vsAI), aiColor(aiColor) {
+    setupBoard();
+    whiteTimer.start(1000*60*10);
+    blackTimer.start(1000*60*10);
+}
+
+void ChessGame::setupBoard() {
+    // Simplified starting position
+    // Pawns
+    for (int i=8;i<16;i++) board[i] = {PieceType::Pawn, Color::White};
+    for (int i=48;i<56;i++) board[i] = {PieceType::Pawn, Color::Black};
+    board[0] = board[7] = {PieceType::Rook, Color::White};
+    board[56] = board[63] = {PieceType::Rook, Color::Black};
+    board[1] = board[6] = {PieceType::Knight, Color::White};
+    board[57] = board[62] = {PieceType::Knight, Color::Black};
+    board[2] = board[5] = {PieceType::Bishop, Color::White};
+    board[58] = board[61] = {PieceType::Bishop, Color::Black};
+    board[3] = {PieceType::Queen, Color::White};
+    board[59] = {PieceType::Queen, Color::Black};
+    board[4] = {PieceType::King, Color::White};
+    board[60] = {PieceType::King, Color::Black};
+}
+
+void ChessGame::loadAI() {
+    // TODO: connect to Stockfish using QProcess
+}
+
+void ChessGame::paintEvent(QPaintEvent*) {
+    QPainter p(this);
+    int squareSize = width() / 8;
+    for (int r=0; r<8; ++r) {
+        for (int c=0; c<8; ++c) {
+            bool dark = (r+c)%2;
+            p.fillRect(c*squareSize, r*squareSize, squareSize, squareSize,
+                       dark ? QColor(118,150,86) : QColor(238,238,210));
+            const Piece& piece = board[r*8+c];
+            if (piece.type != PieceType::None) {
+                QString filename;
+                QString colorPrefix = piece.color == Color::White ? "_w" : "_b";
+                switch(piece.type) {
+                    case PieceType::Pawn: filename = "pawn"; break;
+                    case PieceType::Knight: filename = "knight"; break;
+                    case PieceType::Bishop: filename = "bishop"; break;
+                    case PieceType::Rook: filename = "rook"; break;
+                    case PieceType::Queen: filename = "queen"; break;
+                    case PieceType::King: filename = "king"; break;
+                    default: break;
+                }
+                if (!filename.isEmpty()) {
+                    QPixmap pix(":/images/" + filename + colorPrefix + ".png");
+                    p.drawPixmap(c*squareSize, r*squareSize, squareSize, squareSize, pix);
+                }
+            }
+        }
+    }
+}
+
+void ChessGame::mousePressEvent(QMouseEvent* ev) {
+    // TODO: handle piece selection and move highlighting
+}
+

--- a/src/chessgame.h
+++ b/src/chessgame.h
@@ -1,0 +1,35 @@
+#pragma once
+#include <QWidget>
+#include <QVector>
+#include <QPair>
+#include <QTimer>
+
+enum class PieceType { None, Pawn, Knight, Bishop, Rook, Queen, King };
+enum class Color { White, Black };
+
+struct Piece {
+    PieceType type;
+    Color color;
+};
+
+class ChessGame : public QWidget {
+    Q_OBJECT
+public:
+    explicit ChessGame(bool vsAI = false, Color aiColor = Color::Black, QWidget* parent = nullptr);
+    QSize sizeHint() const override { return QSize(512,512); }
+
+private:
+    QVector<Piece> board;
+    Color turn;
+    bool vsAI;
+    Color aiColor;
+    QTimer whiteTimer;
+    QTimer blackTimer;
+
+    void setupBoard();
+    void loadAI();
+protected:
+    void paintEvent(QPaintEvent*) override;
+    void mousePressEvent(QMouseEvent*) override;
+};
+

--- a/src/login.cpp
+++ b/src/login.cpp
@@ -1,0 +1,72 @@
+#include "login.h"
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QtSql>
+
+LoginDialog::LoginDialog(QWidget* parent) : QDialog(parent), db(nullptr) {
+    setWindowTitle("Login");
+    auto* layout = new QVBoxLayout(this);
+
+    auto* form = new QHBoxLayout;
+    form->addWidget(new QLabel("User:"));
+    userEdit = new QLineEdit;
+    form->addWidget(userEdit);
+    layout->addLayout(form);
+
+    form = new QHBoxLayout;
+    form->addWidget(new QLabel("Password:"));
+    passEdit = new QLineEdit;
+    passEdit->setEchoMode(QLineEdit::Password);
+    form->addWidget(passEdit);
+    layout->addLayout(form);
+
+    auto* buttons = new QHBoxLayout;
+    auto* loginBtn = new QPushButton("Login");
+    auto* signBtn = new QPushButton("Sign Up");
+    buttons->addWidget(loginBtn);
+    buttons->addWidget(signBtn);
+    layout->addLayout(buttons);
+
+    connect(loginBtn, &QPushButton::clicked, this, &LoginDialog::onLogin);
+    connect(signBtn, &QPushButton::clicked, this, &LoginDialog::onSignUp);
+
+    initDatabase();
+}
+
+void LoginDialog::initDatabase() {
+    db = new QSqlDatabase(QSqlDatabase::addDatabase("QSQLITE"));
+    db->setDatabaseName("chess_users.db");
+    if (db->open()) {
+        QSqlQuery q("CREATE TABLE IF NOT EXISTS users (name TEXT PRIMARY KEY, password TEXT)");
+        q.exec();
+    }
+}
+
+void LoginDialog::onLogin() {
+    if (!db || !db->isOpen()) return;
+    QString name = userEdit->text();
+    QString pw = passEdit->text();
+    QSqlQuery q;
+    q.prepare("SELECT password FROM users WHERE name=:name");
+    q.bindValue(":name", name);
+    if (q.exec() && q.next()) {
+        if (q.value(0).toString() == pw) {
+            accept();
+        }
+    }
+}
+
+void LoginDialog::onSignUp() {
+    if (!db || !db->isOpen()) return;
+    QString name = userEdit->text();
+    QString pw = passEdit->text();
+    QSqlQuery q;
+    q.prepare("INSERT OR IGNORE INTO users VALUES(:name,:pw)");
+    q.bindValue(":name", name);
+    q.bindValue(":pw", pw);
+    q.exec();
+}
+

--- a/src/login.h
+++ b/src/login.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <QDialog>
+
+class QLineEdit;
+class QSqlDatabase;
+
+class LoginDialog : public QDialog {
+    Q_OBJECT
+public:
+    explicit LoginDialog(QWidget* parent = nullptr);
+private slots:
+    void onLogin();
+    void onSignUp();
+private:
+    void initDatabase();
+    QSqlDatabase* db;
+    QLineEdit* userEdit;
+    QLineEdit* passEdit;
+};
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,14 @@
+#include <QApplication>
+#include "login.h"
+#include "chessgame.h"
+
+int main(int argc, char** argv) {
+    QApplication app(argc, argv);
+    LoginDialog login;
+    if (login.exec() == QDialog::Accepted) {
+        ChessGame game;
+        game.show();
+        return app.exec();
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- set up CMake project with Qt
- add minimal login dialog backed by SQLite
- create basic chess board widget and main flow
- include chess piece resources
- add build instructions in README

## Testing
- `cmake ..`
- `make -j2`


------
https://chatgpt.com/codex/tasks/task_e_6850d21eab248320aee7840e9c695c13