### PR TITLE
Add interactive chess features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+/build
+*.o
+*.a
+*.so
+cmake-build*/
+*.user
+*.pro.user
+*.db

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.5)
+project(chess-qt LANGUAGES CXX)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_CXX_STANDARD 17)
+
+find_package(Qt5 COMPONENTS Widgets Sql REQUIRED)
+
+add_executable(chess-qt
+    src/main.cpp
+    src/login.cpp
+    src/chessgame.cpp
+    src/startdialog.cpp
+    resources/resources.qrc
+)
+
+target_include_directories(chess-qt PRIVATE src)
+target_link_libraries(chess-qt Qt5::Widgets Qt5::Sql)
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# chess-qt
+# Chess Qt
+
+This project implements a Qt-based chess program in C++.
+Features include:
+
+- Login and simple registration stored in an SQLite database
+- Start dialog offering two player or vs AI play
+- Basic chess board with piece images and selectable pieces
+- Simple move generation and highlight of legal moves
+- Ten minute timers per side
+- Placeholder for Stockfish integration
+
+Build with CMake and Qt5 development packages:
+
+```bash
+mkdir build && cd build
+cmake ..
+make
+./chess-qt
+```
+

--- a/resources/resources.qrc
+++ b/resources/resources.qrc
@@ -1,0 +1,16 @@
+<RCC>
+    <qresource prefix="/images">
+        <file>../bishop_w.png</file>
+        <file>../chess board.png</file>
+        <file>../king_b.png</file>
+        <file>../king_w.png</file>
+        <file>../knight_b.png</file>
+        <file>../knight_w.png</file>
+        <file>../pawn_b.png</file>
+        <file>../pawn_w.png</file>
+        <file>../queen_b.png</file>
+        <file>../queen_w.png</file>
+        <file>../rook_b.png</file>
+        <file>../rook_w.png</file>
+    </qresource>
+</RCC>

--- a/src/chessgame.cpp
+++ b/src/chessgame.cpp
@@ -1,0 +1,168 @@
+#include "chessgame.h"
+#include <QPainter>
+#include <QMouseEvent>
+#include <QMessageBox>
+#include <algorithm>
+
+ChessGame::ChessGame(bool vsAI, Color aiColor, QWidget* parent)
+    : QWidget(parent), board(64), turn(Color::White), vsAI(vsAI), aiColor(aiColor),
+      whiteTime(0,10,0), blackTime(0,10,0), selected(-1) {
+    setupBoard();
+    tick.setInterval(1000);
+    connect(&tick, &QTimer::timeout, this, &ChessGame::checkTimers);
+    tick.start();
+    if(vsAI) loadAI();
+}
+
+void ChessGame::setupBoard() {
+    // Simplified starting position
+    // Pawns
+    for (int i=8;i<16;i++) board[i] = {PieceType::Pawn, Color::White};
+    for (int i=48;i<56;i++) board[i] = {PieceType::Pawn, Color::Black};
+    board[0] = board[7] = {PieceType::Rook, Color::White};
+    board[56] = board[63] = {PieceType::Rook, Color::Black};
+    board[1] = board[6] = {PieceType::Knight, Color::White};
+    board[57] = board[62] = {PieceType::Knight, Color::Black};
+    board[2] = board[5] = {PieceType::Bishop, Color::White};
+    board[58] = board[61] = {PieceType::Bishop, Color::Black};
+    board[3] = {PieceType::Queen, Color::White};
+    board[59] = {PieceType::Queen, Color::Black};
+    board[4] = {PieceType::King, Color::White};
+    board[60] = {PieceType::King, Color::Black};
+}
+
+void ChessGame::loadAI() {
+    // Placeholder for AI connection
+    // In a full implementation we would start Stockfish and communicate via UCI
+}
+
+QVector<int> ChessGame::validMoves(int idx) const {
+    QVector<int> moves;
+    const Piece& p = board[idx];
+    if (p.type == PieceType::None) return moves;
+    int r = idx/8, c = idx%8;
+    auto add=[&](int rr,int cc){
+        if(rr<0||rr>=8||cc<0||cc>=8) return;
+        int d=rr*8+cc;
+        if(board[d].type==PieceType::None || board[d].color!=p.color)
+            moves.append(d);
+    };
+    switch(p.type){
+    case PieceType::Pawn: {
+        int dir = p.color==Color::White?-1:1;
+        int nr=r+dir;
+        if(nr>=0&&nr<8 && board[nr*8+c].type==PieceType::None) moves.append(nr*8+c);
+        if((p.color==Color::White && r==6)||(p.color==Color::Black && r==1)){
+            if(board[(r+dir)*8+c].type==PieceType::None && board[(r+2*dir)*8+c].type==PieceType::None)
+                moves.append((r+2*dir)*8+c);
+        }
+        for(int dc:{-1,1}){
+            int cc=c+dc; nr=r+dir;
+            if(cc>=0&&cc<8 && nr>=0&&nr<8 && board[nr*8+cc].type!=PieceType::None && board[nr*8+cc].color!=p.color)
+                moves.append(nr*8+cc);
+        }
+        break;}
+    case PieceType::Knight:
+        for(auto pr: {std::pair<int,int>{-2,-1},{-2,1},{-1,-2},{-1,2},{1,-2},{1,2},{2,-1},{2,1}})
+            add(r+pr.first,c+pr.second);
+        break;
+    case PieceType::Bishop:
+        for(int dr:{-1,1}) for(int dc:{-1,1})
+            for(int k=1;k<8;k++){int rr=r+dr*k,cc=c+dc*k; if(rr<0||rr>=8||cc<0||cc>=8) break; if(board[rr*8+cc].type==PieceType::None){moves.append(rr*8+cc); continue;} if(board[rr*8+cc].color!=p.color) moves.append(rr*8+cc); break;}
+        break;
+    case PieceType::Rook:
+        for(auto pr: {std::pair<int,int>{1,0},{-1,0},{0,1},{0,-1}})
+            for(int k=1;k<8;k++){int rr=r+pr.first*k,cc=c+pr.second*k; if(rr<0||rr>=8||cc<0||cc>=8) break; if(board[rr*8+cc].type==PieceType::None){moves.append(rr*8+cc); continue;} if(board[rr*8+cc].color!=p.color) moves.append(rr*8+cc); break;}
+        break;
+    case PieceType::Queen:
+        for(auto pr: {std::pair<int,int>{1,0},{-1,0},{0,1},{0,-1},{1,1},{1,-1},{-1,1},{-1,-1}})
+            for(int k=1;k<8;k++){int rr=r+pr.first*k,cc=c+pr.second*k; if(rr<0||rr>=8||cc<0||cc>=8) break; if(board[rr*8+cc].type==PieceType::None){moves.append(rr*8+cc); continue;} if(board[rr*8+cc].color!=p.color) moves.append(rr*8+cc); break;}
+        break;
+    case PieceType::King:
+        for(int dr=-1;dr<=1;dr++) for(int dc=-1;dc<=1;dc++) if(dr||dc) add(r+dr,c+dc);
+        break;
+    default: break;
+    }
+    return moves;
+}
+
+void ChessGame::movePiece(int from, int to){
+    board[to]=board[from];
+    board[from]={PieceType::None,Color::White};
+    selected=-1; highlights.clear();
+    turn = (turn==Color::White?Color::Black:Color::White);
+    if(std::none_of(board.begin(), board.end(), [&](const Piece&p){return p.type==PieceType::King && p.color==(turn==Color::White?Color::Black:Color::White);} ))
+        endGame(turn==Color::White?"White":"Black");
+}
+
+void ChessGame::checkTimers(){
+    if(turn==Color::White) whiteTime=whiteTime.addSecs(-1); else blackTime=blackTime.addSecs(-1);
+    if(whiteTime==QTime(0,0,0)) { endGame("Black"); return; }
+    if(blackTime==QTime(0,0,0)) { endGame("White"); return; }
+    update();
+}
+
+void ChessGame::endGame(const QString& winner){
+    QMessageBox::information(this, "Game Over", winner + " wins");
+    emit gameOver();
+    close();
+}
+
+void ChessGame::paintEvent(QPaintEvent*) {
+    QPainter p(this);
+    int squareSize = width() / 8;
+    for (int r=0; r<8; ++r) {
+        for (int c=0; c<8; ++c) {
+            bool dark = (r+c)%2;
+            p.fillRect(c*squareSize, r*squareSize, squareSize, squareSize,
+                       dark ? QColor(118,150,86) : QColor(238,238,210));
+            int idx=r*8+c;
+            const Piece& piece = board[idx];
+            if (highlights.contains(idx))
+                p.fillRect(c*squareSize, r*squareSize, squareSize, squareSize, QColor(246,246,105,120));
+            if (idx==selected)
+                p.fillRect(c*squareSize, r*squareSize, squareSize, squareSize, QColor(186,202,68,120));
+            if (piece.type != PieceType::None) {
+                QString filename;
+                QString colorPrefix = piece.color == Color::White ? "_w" : "_b";
+                switch(piece.type) {
+                    case PieceType::Pawn: filename = "pawn"; break;
+                    case PieceType::Knight: filename = "knight"; break;
+                    case PieceType::Bishop: filename = "bishop"; break;
+                    case PieceType::Rook: filename = "rook"; break;
+                    case PieceType::Queen: filename = "queen"; break;
+                    case PieceType::King: filename = "king"; break;
+                    default: break;
+                }
+                if (!filename.isEmpty()) {
+                    QPixmap pix(":/images/" + filename + colorPrefix + ".png");
+                    p.drawPixmap(c*squareSize, r*squareSize, squareSize, squareSize, pix);
+                }
+            }
+        }
+    }
+    p.setPen(Qt::black);
+    p.drawText(rect(), Qt::AlignBottom | Qt::AlignLeft, whiteTime.toString("mm:ss"));
+    p.drawText(rect(), Qt::AlignTop | Qt::AlignLeft, blackTime.toString("mm:ss"));
+}
+
+void ChessGame::mousePressEvent(QMouseEvent* ev) {
+    int sq = (ev->y()/ (height()/8))*8 + (ev->x()/(width()/8));
+    if(selected==-1){
+        if(board[sq].type!=PieceType::None && board[sq].color==turn){
+            selected=sq;
+            highlights=validMoves(sq);
+        }
+    } else {
+        if(highlights.contains(sq))
+            movePiece(selected,sq);
+        else if(board[sq].type!=PieceType::None && board[sq].color==turn){
+            selected=sq;
+            highlights=validMoves(sq);
+        } else {
+            selected=-1; highlights.clear();
+        }
+    }
+    update();
+}
+

--- a/src/chessgame.h
+++ b/src/chessgame.h
@@ -1,0 +1,46 @@
+#pragma once
+#include <QWidget>
+#include <QVector>
+#include <QPair>
+#include <QTimer>
+#include <QTime>
+
+enum class PieceType { None, Pawn, Knight, Bishop, Rook, Queen, King };
+enum class Color { White, Black };
+
+struct Piece {
+    PieceType type;
+    Color color;
+};
+
+class ChessGame : public QWidget {
+    Q_OBJECT
+public:
+    explicit ChessGame(bool vsAI = false, Color aiColor = Color::Black, QWidget* parent = nullptr);
+    QSize sizeHint() const override { return QSize(512,512); }
+
+signals:
+    void gameOver();
+
+private:
+    QVector<Piece> board;
+    Color turn;
+    bool vsAI;
+    Color aiColor;
+    QTime whiteTime;
+    QTime blackTime;
+    QTimer tick;
+    int selected;
+    QVector<int> highlights;
+
+    void setupBoard();
+    void loadAI();
+    QVector<int> validMoves(int idx) const;
+    void movePiece(int from, int to);
+    void checkTimers();
+    void endGame(const QString& winner);
+protected:
+    void paintEvent(QPaintEvent*) override;
+    void mousePressEvent(QMouseEvent*) override;
+};
+

--- a/src/login.cpp
+++ b/src/login.cpp
@@ -1,0 +1,72 @@
+#include "login.h"
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QtSql>
+
+LoginDialog::LoginDialog(QWidget* parent) : QDialog(parent), db(nullptr) {
+    setWindowTitle("Login");
+    auto* layout = new QVBoxLayout(this);
+
+    auto* form = new QHBoxLayout;
+    form->addWidget(new QLabel("User:"));
+    userEdit = new QLineEdit;
+    form->addWidget(userEdit);
+    layout->addLayout(form);
+
+    form = new QHBoxLayout;
+    form->addWidget(new QLabel("Password:"));
+    passEdit = new QLineEdit;
+    passEdit->setEchoMode(QLineEdit::Password);
+    form->addWidget(passEdit);
+    layout->addLayout(form);
+
+    auto* buttons = new QHBoxLayout;
+    auto* loginBtn = new QPushButton("Login");
+    auto* signBtn = new QPushButton("Sign Up");
+    buttons->addWidget(loginBtn);
+    buttons->addWidget(signBtn);
+    layout->addLayout(buttons);
+
+    connect(loginBtn, &QPushButton::clicked, this, &LoginDialog::onLogin);
+    connect(signBtn, &QPushButton::clicked, this, &LoginDialog::onSignUp);
+
+    initDatabase();
+}
+
+void LoginDialog::initDatabase() {
+    db = new QSqlDatabase(QSqlDatabase::addDatabase("QSQLITE"));
+    db->setDatabaseName("chess_users.db");
+    if (db->open()) {
+        QSqlQuery q("CREATE TABLE IF NOT EXISTS users (name TEXT PRIMARY KEY, password TEXT)");
+        q.exec();
+    }
+}
+
+void LoginDialog::onLogin() {
+    if (!db || !db->isOpen()) return;
+    QString name = userEdit->text();
+    QString pw = passEdit->text();
+    QSqlQuery q;
+    q.prepare("SELECT password FROM users WHERE name=:name");
+    q.bindValue(":name", name);
+    if (q.exec() && q.next()) {
+        if (q.value(0).toString() == pw) {
+            accept();
+        }
+    }
+}
+
+void LoginDialog::onSignUp() {
+    if (!db || !db->isOpen()) return;
+    QString name = userEdit->text();
+    QString pw = passEdit->text();
+    QSqlQuery q;
+    q.prepare("INSERT OR IGNORE INTO users VALUES(:name,:pw)");
+    q.bindValue(":name", name);
+    q.bindValue(":pw", pw);
+    q.exec();
+}
+

--- a/src/login.h
+++ b/src/login.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <QDialog>
+
+class QLineEdit;
+class QSqlDatabase;
+
+class LoginDialog : public QDialog {
+    Q_OBJECT
+public:
+    explicit LoginDialog(QWidget* parent = nullptr);
+private slots:
+    void onLogin();
+    void onSignUp();
+private:
+    void initDatabase();
+    QSqlDatabase* db;
+    QLineEdit* userEdit;
+    QLineEdit* passEdit;
+};
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,27 @@
+#include <QApplication>
+#include "login.h"
+#include "chessgame.h"
+#include "startdialog.h"
+#include <memory>
+#include <functional>
+
+int main(int argc, char** argv) {
+    QApplication app(argc, argv);
+    LoginDialog login;
+    if (login.exec() != QDialog::Accepted)
+        return 0;
+
+    std::function<void()> startGame;
+    std::shared_ptr<ChessGame> game;
+    startGame = [&]() {
+        StartDialog dlg;
+        if (dlg.exec() != QDialog::Accepted) { app.quit(); return; }
+        bool vsAI = dlg.mode() == GameMode::VsAI;
+        game.reset(new ChessGame(vsAI, dlg.aiColor()));
+        QObject::connect(game.get(), &ChessGame::gameOver, startGame);
+        game->show();
+    };
+
+    startGame();
+    return app.exec();
+}

--- a/src/startdialog.cpp
+++ b/src/startdialog.cpp
@@ -1,0 +1,33 @@
+#include "startdialog.h"
+#include <QVBoxLayout>
+
+StartDialog::StartDialog(QWidget* parent) : QDialog(parent), chosenMode(GameMode::TwoPlayer), chosenColor(Color::White) {
+    setWindowTitle("New Game");
+    auto* layout = new QVBoxLayout(this);
+    twoPlayerRadio = new QRadioButton("Two Player");
+    aiRadio = new QRadioButton("Vs AI");
+    twoPlayerRadio->setChecked(true);
+    layout->addWidget(twoPlayerRadio);
+    layout->addWidget(aiRadio);
+    colorBox = new QComboBox;
+    colorBox->addItem("White", static_cast<int>(Color::White));
+    colorBox->addItem("Black", static_cast<int>(Color::Black));
+    colorBox->addItem("Random", -1);
+    colorBox->setEnabled(false);
+    layout->addWidget(colorBox);
+    connect(aiRadio, &QRadioButton::toggled, colorBox, &QWidget::setEnabled);
+    auto* start = new QPushButton("Start");
+    layout->addWidget(start);
+    connect(start, &QPushButton::clicked, this, &StartDialog::acceptGame);
+}
+
+void StartDialog::acceptGame() {
+    chosenMode = aiRadio->isChecked() ? GameMode::VsAI : GameMode::TwoPlayer;
+    int data = colorBox->currentData().toInt();
+    if (data == -1) {
+        chosenColor = (qrand() % 2) ? Color::White : Color::Black;
+    } else {
+        chosenColor = static_cast<Color>(data);
+    }
+    accept();
+}

--- a/src/startdialog.h
+++ b/src/startdialog.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <QDialog>
+#include <QRadioButton>
+#include <QComboBox>
+#include <QPushButton>
+#include "chessgame.h"
+
+enum class GameMode { TwoPlayer, VsAI };
+
+class StartDialog : public QDialog {
+    Q_OBJECT
+public:
+    explicit StartDialog(QWidget* parent = nullptr);
+    GameMode mode() const { return chosenMode; }
+    Color aiColor() const { return chosenColor; }
+private slots:
+    void acceptGame();
+private:
+    GameMode chosenMode;
+    Color chosenColor;
+    QRadioButton* twoPlayerRadio;
+    QRadioButton* aiRadio;
+    QComboBox* colorBox;
+};


### PR DESCRIPTION
## Summary
- implement start dialog for choosing 2-player or AI games
- extend chess logic with move generation, selection and timers
- highlight legal moves and display player clocks
- update main flow to loop from login through game end

## Testing
- `cmake ..`
- `make -j2`


------
https://chatgpt.com/codex/tasks/task_e_6850d21eab248320aee7840e9c695c13